### PR TITLE
BI-1178: apply hackz

### DIFF
--- a/lib/bigshift/big_query/table.rb
+++ b/lib/bigshift/big_query/table.rb
@@ -37,9 +37,7 @@ module BigShift
               job.status.errors.each do |error|
                 message = %<Load error: "#{error.message}">
                 if error.location
-                  file, line, field = error.location.split('/').map { |s| s.split(':').last.strip }
-                  message << " at file #{file}, line #{line}"
-                  message << ", field #{field}" if field
+                  message << error.location
                 end
                 @logger.debug(message)
               end

--- a/lib/bigshift/redshift_table_schema.rb
+++ b/lib/bigshift/redshift_table_schema.rb
@@ -54,9 +54,9 @@ module BigShift
         when /^numeric/, /int/, /^double/, 'real'
           sprintf('"%s"', @name)
         when /^character/
-          sprintf(%q<('"' || REPLACE(REPLACE(REPLACE("%s", '"', '""'), '\\n', '\\\\n'), '\\r', '\\\\r') || '"')>, @name)
+          sprintf(%q<('"' || REPLACE(REPLACE(REPLACE("%s", '"', '""'), '\\n', ''), '\\r', '') || '"')>, @name)
         when /^timestamp/
-          sprintf('(EXTRACT(epoch FROM "%s") + EXTRACT(milliseconds FROM "%s")/1000.0)', @name, @name)
+          sprintf(%q<(TO_CHAR("%s", 'YYYY-MM-DD HH24:MI:SS'))>, @name)
         when 'date'
           sprintf(%q<(TO_CHAR("%s", 'YYYY-MM-DD'))>, @name)
         when 'boolean'


### PR DESCRIPTION
table.rb:40 modified the error processing because I was getting an error at the original line 40. Modified to just append the whole contents of the error to the message.

redshift_table_schema.rb:57 Escaping newlines wasn't working. The import process still saw a single record split over multiple lines. I changed this to just strip the newlines and carriage returns.

redshift_table_schema.rb:59 We had timestamps in our redshift database that are outside the range of the epoch so when it was trying to do a conversion we would get an over/under flow error. I modified this line to just print out the string value of the timestamp which still works in the import.