### PR TITLE
Bi 1339

### DIFF
--- a/bigshift.gemspec
+++ b/bigshift.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'pg'
-  s.add_runtime_dependency 'google-api-client', '~> 0.9'
-  s.add_runtime_dependency 'googleauth'
+  s.add_runtime_dependency 'pg', '= 0.19.0'
+  s.add_runtime_dependency 'google-api-client', '= 0.9.20'
+  s.add_runtime_dependency 'googleauth', '= 0.5.1'
   s.add_runtime_dependency 'aws-sdk', '= 2.6.15'
 end

--- a/lib/bigshift/redshift_table_schema.rb
+++ b/lib/bigshift/redshift_table_schema.rb
@@ -84,7 +84,7 @@ module BigShift
             'INTEGER'
           when 'boolean' then
             'BOOLEAN'
-          when /^double/, 'real', 'numeric' then
+          when /^double/, 'real', /^numeric/ then
             'FLOAT'
           else
             raise sprintf('Unsupported column type: %s', type.inspect)

--- a/lib/bigshift/version.rb
+++ b/lib/bigshift/version.rb
@@ -1,3 +1,3 @@
 module BigShift
-  VERSION = '0.3.2'.freeze
+  VERSION = '0.3.2.1'.freeze
 end


### PR DESCRIPTION
* Specific version dependencies to limit breakages
* Type 'numeric' should be a pattern so it can be mapped to FLOAT in big query
